### PR TITLE
attach expects empty string for aname

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ impl<Stream: Write + Read> SimpleClient for Client<Stream> {
             fid: 0,
             afid: !0,
             uname: uname.into(),
-            aname: "/".into(),
+            aname: "".into(),
         };
 
         self.send_msg(&attach).unwrap();


### PR DESCRIPTION
See https://github.com/9fans/go/blob/a7dc9e765ba9dc77c1b3eb5bf553e16ff8fda82d/plan9/client/dial.go#L41 for a reference implementation.